### PR TITLE
Adding dependency on xPSDesiredStateConfiguration (Fixes #10, fixes #11)

### DIFF
--- a/DSCResources/MSFT_xChrome/MSFT_xChrome.schema.psm1
+++ b/DSCResources/MSFT_xChrome/MSFT_xChrome.schema.psm1
@@ -4,23 +4,26 @@
 Configuration MSFT_xChrome {
     param
     (
-    [string]$Language = "en",
-    [string]$LocalPath = "$env:SystemDrive\Windows\DtlDownloads\GoogleChromeStandaloneEnterprise.msi"
+        [string]
+        $Language = "en",
+        [string]
+        $LocalPath = "$env:SystemDrive\Windows\DtlDownloads\GoogleChromeStandaloneEnterprise.msi"
     )
+    
     Import-DscResource -ModuleName xPSDesiredStateConfiguration
 
     xRemoteFile Downloader
     {
-        Uri = "https://dl.google.com/tag/s/appguid={8A69D345-D564-463C-AFF1-A69D9E530F96}&iid={00000000-0000-0000-0000-000000000000}&lang="+$Language+"&browser=3&usagestats=0&appname=Google%2520Chrome&needsadmin=prefers/edgedl/chrome/install/GoogleChromeStandaloneEnterprise.msi" 
+        Uri = "https://dl.google.com/tag/s/appguid={8A69D345-D564-463C-AFF1-A69D9E530F96}&iid={00000000-0000-0000-0000-000000000000}&lang=" + $Language + "&browser=3&usagestats=0&appname=Google%2520Chrome&needsadmin=prefers/edgedl/chrome/install/GoogleChromeStandaloneEnterprise.msi" 
         DestinationPath = $LocalPath
     }
      
     Package Installer
     {
-    Ensure = "Present"
-    Path = $LocalPath
-    Name = "Google Chrome"
-    ProductId = ''
+        Ensure = "Present"
+        Path = $LocalPath
+        Name = "Google Chrome"
+        ProductId = ''
         DependsOn = "[xRemoteFile]Downloader"
     }
 }

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ The **MSFT_xChrome** DSC Resource has following optional properties:
 
 ### Unreleased
 
+* Added missing dependency on xPSDesiredStateConfiguration
+
 ### 1.0.2.0
 
 * Minor documentation updates

--- a/xChrome.psd1
+++ b/xChrome.psd1
@@ -12,7 +12,7 @@
 # RootModule = ''
 
 # Version number of this module.
-ModuleVersion = '1.1.0.0'
+ModuleVersion = '1.0.2.0'
 
 # ID used to uniquely identify this module
 GUID = 'f7882c21-0820-4d27-811f-c095e1a91ec3'
@@ -48,7 +48,7 @@ Description = 'PowerShell Desired State Configuration (DSC) module for installin
 # ProcessorArchitecture = ''
 
 # Modules that must be imported into the global environment prior to importing this module
-# RequiredModules = @()
+RequiredModules = @(xPSDesiredStateConfiguration)
 
 # Assemblies that must be loaded prior to importing this module
 # RequiredAssemblies = @()

--- a/xChrome.psd1
+++ b/xChrome.psd1
@@ -12,7 +12,7 @@
 # RootModule = ''
 
 # Version number of this module.
-ModuleVersion = '1.0.2.0'
+ModuleVersion = '1.1.0.0'
 
 # ID used to uniquely identify this module
 GUID = 'f7882c21-0820-4d27-811f-c095e1a91ec3'

--- a/xChrome.psd1
+++ b/xChrome.psd1
@@ -48,7 +48,7 @@ Description = 'PowerShell Desired State Configuration (DSC) module for installin
 # ProcessorArchitecture = ''
 
 # Modules that must be imported into the global environment prior to importing this module
-RequiredModules = @(xPSDesiredStateConfiguration)
+RequiredModules = @( 'xPSDesiredStateConfiguration' )
 
 # Assemblies that must be loaded prior to importing this module
 # RequiredAssemblies = @()


### PR DESCRIPTION
This dependency is required since the module calls Import-DscResource xPSDesiredStateConfiguration.
This fixes both #10 and #11.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xchrome/12)

<!-- Reviewable:end -->
